### PR TITLE
Agregar CORS para integrar el backend con el frontend local

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,17 @@ Los demás usuarios cargados desde `src/data/store.js` tienen como contraseña:
 
 - `User12345`
 
+## 🔗 Integración local con el frontend
+
+El backend está preparado para recibir peticiones desde el frontend local en:
+
+- `http://localhost:5173`
+- `http://127.0.0.1:5173`
+
+Se habilitan los headers necesarios para `Authorization`, `Content-Type` y las
+peticiones `OPTIONS` que requiere el navegador antes de consumir rutas
+protegidas.
+
 ## ⚙️ Cómo ejecutar el servidor
 1. Asegúrate de tener Node.js instalado (versión 18+ recomendada).
 2. Desde el directorio raíz del proyecto, instala dependencias si es necesario:
@@ -74,9 +85,27 @@ Los demás usuarios cargados desde `src/data/store.js` tienen como contraseña:
    ```
 4. El servidor escuchará en el puerto **3000**. Prueba los endpoints con tu navegador o `curl`:
    ```bash
-   curl http://localhost:3000/users
-   curl -X POST http://localhost:3000/tasks
+   curl -X POST http://localhost:3000/api/auth/login \
+     -H "Content-Type: application/json" \
+     -d '{"email":"carlos.ramirez@email.com","password":"Admin12345"}'
+
+   curl http://localhost:3000/api/users \
+     -H "Authorization: Bearer <TOKEN>"
    ```
+
+## 🖥️ Flujo recomendado junto al frontend
+
+1. Inicia este backend:
+   ```bash
+   npm install
+   node src/main.js
+   ```
+2. En `Proyecto-Integrador-Frontend`, ejecuta:
+   ```bash
+   npm install
+   npm run dev
+   ```
+3. Abre `http://localhost:5173` e inicia sesión con las credenciales de prueba.
 
 ---
 

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,28 @@ import routesTasks from './routes/tasks.routes.js';
 
 export const app = express();
 const PORT = 3000;
+const ALLOWED_ORIGINS = new Set([
+    'http://localhost:5173',
+    'http://127.0.0.1:5173'
+]);
+
+app.use((req, res, next) => {
+    const requestOrigin = req.headers.origin;
+
+    if (requestOrigin && ALLOWED_ORIGINS.has(requestOrigin)) {
+        res.setHeader('Access-Control-Allow-Origin', requestOrigin);
+        res.setHeader('Vary', 'Origin');
+    }
+
+    res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,PATCH,DELETE,OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type');
+
+    if (req.method === 'OPTIONS') {
+        return res.status(204).end();
+    }
+
+    next();
+});
 
 // Middleware para parsear bodies JSON
 app.use(express.json());


### PR DESCRIPTION
## Resumen
Este PR agrega la configuración necesaria en el backend para permitir el consumo desde el frontend local durante desarrollo.

## Cambios realizados
- Se añade middleware CORS explícito en el arranque de Express.
- Se permiten los orígenes:
  - `http://localhost:5173`
  - `http://127.0.0.1:5173`
- Se habilitan los headers `Authorization` y `Content-Type`.
- Se responde correctamente a peticiones `OPTIONS`.
- Se actualiza la documentación del backend con instrucciones de uso y ejemplos alineados con `/api`.

## Impacto
- No se modifican rutas, contratos, payloads ni lógica de negocio.
- Se mantiene intacto el sistema de autenticación, roles y usuarios semilla.
- El backend queda listo para integrarse con el frontend local sin errores de CORS.

## Validación
- Se verificó la carga del archivo principal del backend.
- El backend sigue arrancando correctamente en el puerto `3000`.
- La validación HTTP completa de preflight quedó limitada por restricciones del sandbox.

## Notas
Este PR complementa la configuración del frontend para que el flujo local funcione de forma coordinada.
