### PR TITLE
Migra los modelos del backend para usar MySQL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
 # Configuración del Servidor
-PORT =
+PORT=3000
 
 # Configuración de la Base de Datos MySQL
-DB_HOST =
-DB_USER =
-DB_PASSWORD =
-DB_NAME =
-DB_PORT =
+DB_HOST=localhost
+DB_USER=task_manager_app
+DB_PASSWORD=TaskManager123!
+DB_NAME=tasks_manager_group3
+DB_PORT=3306

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 .env
 package-lock.json
+bun.lock

--- a/database-user.sql
+++ b/database-user.sql
@@ -1,0 +1,16 @@
+-- ============================================================
+--  Usuario de aplicacion para tasks_manager_group3
+--  Uso local/desarrollo
+-- ============================================================
+
+CREATE DATABASE IF NOT EXISTS tasks_manager_group3;
+
+CREATE USER IF NOT EXISTS 'task_manager_app'@'localhost'
+IDENTIFIED BY 'TaskManager123!';
+
+ALTER USER 'task_manager_app'@'localhost'
+IDENTIFIED BY 'TaskManager123!';
+
+GRANT ALL PRIVILEGES ON tasks_manager_group3.* TO 'task_manager_app'@'localhost';
+
+FLUSH PRIVILEGES;

--- a/readme.md
+++ b/readme.md
@@ -1,28 +1,127 @@
 # Task Manager Backend
 
-Proyecto de prueba para **GFPI-F-135 V04** que establece una API básica de gestión de usuarios y tareas.
+Backend del proyecto integrador para la gestión de usuarios y tareas. Expone una
+API REST con autenticación, dashboard administrativo, gestión de usuarios,
+gestión de tareas y asignación múltiple de usuarios por tarea.
 
-## 📌 Propósito
-Este repositorio contiene un servidor Express inicial con rutas de ejemplo que servirán como base para un gestor de tareas. La idea es validar la arquitectura y la estructura del proyecto sin lógica de negocio compleja ni base de datos.
+## Propósito
 
-## 🗂️ Estructura del proyecto
-```
+Este proyecto funciona como la capa backend del gestor de tareas. La API está
+construida con Express y actualmente usa MySQL como capa de persistencia para:
+
+- autenticación de usuarios
+- consulta de dashboard
+- CRUD de usuarios
+- CRUD de tareas
+- asignaciones entre tareas y usuarios
+
+## Tecnologías
+
+- Node.js
+- Express
+- MySQL
+- mysql2
+- dotenv
+
+## Estructura del proyecto
+
+```text
+├── database.sql          # esquema principal y datos iniciales
+├── database-user.sql     # usuario de aplicación para MySQL
 ├── package.json
-├── readme.md               # este documento
+├── readme.md
 └── src/
-    ├── data/
-    │   └── store.js        # datos iniciales en memoria con arrays y objetos
-    ├── main.js             # punto de entrada de la aplicación
-    ├── controllers/        # lógica HTTP por módulo
-    ├── models/             # acceso a datos en memoria y reglas de negocio
-    └── routes/             # definición de endpoints
+    ├── config/           # configuración de conexión y variables de entorno
+    ├── controllers/      # lógica HTTP
+    ├── middlewares/      # autenticación y autorización
+    ├── models/           # acceso a datos y reglas de negocio
+    ├── routes/           # endpoints de la API
+    └── main.js           # punto de entrada del servidor
 ```
 
-> Los datos simulados del proyecto se cargan desde `src/data/store.js`, sin depender de `db.json`.
+## Configuración de base de datos
 
-## 🔌 Endpoints disponibles
+La base esperada por el proyecto es:
+
+- base de datos: `tasks_manager_group3`
+- usuario de aplicación: `task_manager_app`
+- puerto por defecto: `3306`
+
+### 1. Crear la base y las tablas
+
+Desde la raíz del proyecto ejecuta:
+
+```bash
+mysql -uroot -p < database.sql
+```
+
+### 2. Crear el usuario de aplicación
+
+```bash
+mysql -uroot -p < database-user.sql
+```
+
+El script crea este usuario local:
+
+- `DB_USER=task_manager_app`
+- `DB_PASSWORD=TaskManager123!`
+
+## Variables de entorno
+
+Usa `.env.example` como base para crear tu archivo `.env`.
+
+Ejemplo:
+
+```env
+PORT=3000
+DB_HOST=localhost
+DB_USER=task_manager_app
+DB_PASSWORD=TaskManager123!
+DB_NAME=tasks_manager_group3
+DB_PORT=3306
+```
+
+## Instalación y ejecución
+
+1. Instala dependencias:
+   ```bash
+   npm install
+   ```
+2. Crea tu archivo `.env` con la configuración de MySQL.
+3. Levanta el servidor:
+   ```bash
+   npm run dev
+   ```
+
+También puedes iniciarlo sin nodemon:
+
+```bash
+node src/main.js
+```
+
+El backend queda disponible en:
+
+```text
+http://localhost:3000
+```
+
+## Integración local con el frontend
+
+El backend está preparado para recibir peticiones desde el frontend local en:
+
+- `http://localhost:5173`
+- `http://127.0.0.1:5173`
+
+Se habilitan los headers necesarios para:
+
+- `Authorization`
+- `Content-Type`
+- peticiones `OPTIONS`
+
+## Endpoints disponibles
 
 ### Usuarios
+
 - `POST /api/users`
 - `GET /api/users`
 - `GET /api/users/:userId`
@@ -32,6 +131,7 @@ Este repositorio contiene un servidor Express inicial con rutas de ejemplo que s
 - `GET /api/users/:userId/tasks`
 
 ### Tareas
+
 - `POST /api/tasks`
 - `GET /api/tasks`
 - `GET /api/tasks/:taskId`
@@ -44,70 +144,59 @@ Este repositorio contiene un servidor Express inicial con rutas de ejemplo que s
 - `GET /api/tasks/filter`
 
 ### Autenticación y dashboard
+
 - `POST /api/auth/login`
 - `GET /api/dashboard`
 
-## 🔁 Relación usuarios-tareas
+## Credenciales de prueba
 
-Las tareas ahora soportan asignación múltiple mediante el campo `assignedUserIds`, lo que permite que una misma tarea pertenezca a varios usuarios al mismo tiempo.
-
-## 🔐 Acceso de prueba
-
-El proyecto incluye un usuario administrador en la semilla inicial:
+Administrador:
 
 - `email`: `carlos.ramirez@email.com`
 - `password`: `Admin12345`
 
-Los demás usuarios cargados desde `src/data/store.js` tienen como contraseña:
+Usuarios estándar:
 
-- `User12345`
+- usa cualquiera de los correos insertados en `database.sql`
+- `password`: `User12345`
 
-## 🔗 Integración local con el frontend
+## Prueba rápida del API
 
-El backend está preparado para recibir peticiones desde el frontend local en:
+### Login
 
-- `http://localhost:5173`
-- `http://127.0.0.1:5173`
+```bash
+curl -X POST http://localhost:3000/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"carlos.ramirez@email.com","password":"Admin12345"}'
+```
 
-Se habilitan los headers necesarios para `Authorization`, `Content-Type` y las
-peticiones `OPTIONS` que requiere el navegador antes de consumir rutas
-protegidas.
+### Consultar usuarios con token
 
-## ⚙️ Cómo ejecutar el servidor
-1. Asegúrate de tener Node.js instalado (versión 18+ recomendada).
-2. Desde el directorio raíz del proyecto, instala dependencias si es necesario:
+```bash
+curl http://localhost:3000/api/users \
+  -H "Authorization: Bearer <TOKEN>"
+```
+
+## Flujo recomendado junto al frontend
+
+1. En este proyecto:
    ```bash
    npm install
+   npm run dev
    ```
-3. Inicia el servidor:
-   ```bash
-   node src/main.js
-   ```
-4. El servidor escuchará en el puerto **3000**. Prueba los endpoints con tu navegador o `curl`:
-   ```bash
-   curl -X POST http://localhost:3000/api/auth/login \
-     -H "Content-Type: application/json" \
-     -d '{"email":"carlos.ramirez@email.com","password":"Admin12345"}'
-
-   curl http://localhost:3000/api/users \
-     -H "Authorization: Bearer <TOKEN>"
-   ```
-
-## 🖥️ Flujo recomendado junto al frontend
-
-1. Inicia este backend:
-   ```bash
-   npm install
-   node src/main.js
-   ```
-2. En `Proyecto-Integrador-Frontend`, ejecuta:
+2. En `Proyecto-Integrador-Frontend`:
    ```bash
    npm install
    npm run dev
    ```
 3. Abre `http://localhost:5173` e inicia sesión con las credenciales de prueba.
 
----
+## Notas funcionales
+
+- Las tareas soportan asignación múltiple mediante la tabla `task_users`.
+- El estado de la tarea es global por tarea, no individual por usuario.
+- Si un usuario asignado cambia el estado a `completada`, los demás verán la
+  misma tarea como `completada`.
 
 ## Integrantes
 

--- a/src/config/db.js
+++ b/src/config/db.js
@@ -6,11 +6,11 @@ import "dotenv/config";
 // Creamos un "Pool" de conexiones.
 // Es mucho más eficiente que abrir y cerrar una conexión por cada consulta.
 const pool = mysql.createPool({
-  host: process.env.DB_HOST,
+  host: process.env.DB_HOST || "localhost",
   user: process.env.DB_USER,
-  password: process.env.DB_PASSWORD,
-  database: process.env.DB_NAME,
-  port: process.env.DB_PORT,
+  password: process.env.DB_PASSWORD || "",
+  database: process.env.DB_NAME || "tasks_manager_group3",
+  port: Number(process.env.DB_PORT || 3306),
   waitForConnections: true,
   connectionLimit: 10, // Máximo de conexiones simultáneas
   queueLimit: 0,

--- a/src/models/auth/login.model.js
+++ b/src/models/auth/login.model.js
@@ -1,5 +1,5 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
-import { usersDatabase } from '../database.js';
+import { findUserByEmailInDb, findUserByIdInDb } from '../database.js';
 import { createModelError } from '../errors.js';
 
 const AUTH_SECRET = 'task-manager-secret';
@@ -29,8 +29,6 @@ const createAuthToken = (user) => {
     return `${header}.${payload}.${signature}`;
 };
 
-const findUserByEmail = (email) => usersDatabase.find((user) => user.email === email);
-
 export const loginModel = async ({ email, password }) => {
     const normalizedEmail = email?.trim().toLowerCase();
     const normalizedPassword = password?.trim();
@@ -39,7 +37,7 @@ export const loginModel = async ({ email, password }) => {
         throw createModelError('Email y password son requeridos');
     }
 
-    const user = findUserByEmail(normalizedEmail);
+    const user = await findUserByEmailInDb(normalizedEmail);
 
     if (!user || user.password !== normalizedPassword) {
         throw createModelError('Credenciales inválidas', 401);
@@ -95,7 +93,7 @@ export const verifyTokenModel = async (token) => {
         throw createModelError('Token expirado o inválido', 401);
     }
 
-    const user = usersDatabase.find((currentUser) => currentUser.id === parsedPayload.sub);
+    const user = await findUserByIdInDb(parsedPayload.sub);
 
     if (!user) {
         throw createModelError('Usuario no encontrado para el token', 401);

--- a/src/models/dashboard/get.model.js
+++ b/src/models/dashboard/get.model.js
@@ -1,32 +1,56 @@
-import { tasksDatabase, usersDatabase } from '../database.js';
-
-const countByStatus = (status) => tasksDatabase.filter((task) => task.status === status).length;
-const countByPriority = (priority) => tasksDatabase.filter((task) => task.priority === priority).length;
+import pool from '../database.js';
 
 export const getDashboardModel = async () => {
-    const totalTasks = tasksDatabase.length;
-    const totalUsers = usersDatabase.length;
+    const [[userStats]] = await pool.query(`
+        SELECT
+            COUNT(*) AS users,
+            COALESCE(SUM(status = 'activo'), 0) AS activeUsers,
+            COALESCE(SUM(status = 'inactivo'), 0) AS inactiveUsers,
+            COALESCE(SUM(status = 'suspendido'), 0) AS suspendedUsers,
+            COALESCE(SUM(status = 'eliminado'), 0) AS deletedUsers
+        FROM users
+    `);
+
+    const [[taskStats]] = await pool.query(`
+        SELECT
+            COUNT(*) AS tasks,
+            COALESCE(SUM(status = 'pendiente'), 0) AS pendiente,
+            COALESCE(SUM(status = 'en progreso'), 0) AS enProgreso,
+            COALESCE(SUM(status = 'completada'), 0) AS completada,
+            COALESCE(SUM(priority = 'baja'), 0) AS baja,
+            COALESCE(SUM(priority = 'media'), 0) AS media,
+            COALESCE(SUM(priority = 'alta'), 0) AS alta
+        FROM tasks
+    `);
+
+    const [[assignmentStats]] = await pool.query(`
+        SELECT COUNT(DISTINCT task_id) AS assignedTasks
+        FROM task_users
+    `);
+
+    const totalTasks = Number(taskStats.tasks || 0);
+    const assignedTasks = Number(assignmentStats.assignedTasks || 0);
 
     return {
         totals: {
-            users: totalUsers,
-            activeUsers: usersDatabase.filter((user) => user.status === 'activo').length,
-            inactiveUsers: usersDatabase.filter((user) => user.status === 'inactivo').length,
-            suspendedUsers: usersDatabase.filter((user) => user.status === 'suspendido').length,
-            deletedUsers: usersDatabase.filter((user) => user.status === 'eliminado').length,
+            users: Number(userStats.users || 0),
+            activeUsers: Number(userStats.activeUsers || 0),
+            inactiveUsers: Number(userStats.inactiveUsers || 0),
+            suspendedUsers: Number(userStats.suspendedUsers || 0),
+            deletedUsers: Number(userStats.deletedUsers || 0),
             tasks: totalTasks,
-            assignedTasks: tasksDatabase.filter((task) => task.assignedUserIds.length > 0).length,
-            unassignedTasks: tasksDatabase.filter((task) => task.assignedUserIds.length === 0).length
+            assignedTasks,
+            unassignedTasks: Math.max(totalTasks - assignedTasks, 0)
         },
         tasksByStatus: {
-            pendiente: countByStatus('pendiente'),
-            enProgreso: countByStatus('en progreso'),
-            completada: countByStatus('completada')
+            pendiente: Number(taskStats.pendiente || 0),
+            enProgreso: Number(taskStats.enProgreso || 0),
+            completada: Number(taskStats.completada || 0)
         },
         tasksByPriority: {
-            baja: countByPriority('baja'),
-            media: countByPriority('media'),
-            alta: countByPriority('alta')
+            baja: Number(taskStats.baja || 0),
+            media: Number(taskStats.media || 0),
+            alta: Number(taskStats.alta || 0)
         }
     };
 };

--- a/src/models/database.js
+++ b/src/models/database.js
@@ -1,47 +1,198 @@
-import { seedData } from '../data/store.js';
+import pool from '../config/db.js';
+import { createModelError } from './errors.js';
 
-// Normaliza los usuarios cargados desde la semilla.
-const normalizeUser = (user) => {
-    const timestamp = new Date().toISOString();
+const USER_SELECT_FIELDS = `
+    id,
+    firstName,
+    lastName,
+    email,
+    status,
+    role,
+    password,
+    createdAt,
+    updatedAt
+`;
+
+const normalizeDateValue = (value) => {
+    if (!value) {
+        return null;
+    }
+
+    const parsedDate = value instanceof Date ? value : new Date(value);
+
+    if (Number.isNaN(parsedDate.getTime())) {
+        return value;
+    }
+
+    return parsedDate.toISOString();
+};
+
+const parseAssignedUserIds = (value) => {
+    if (Array.isArray(value)) {
+        return value.map((userId) => String(userId).trim()).filter(Boolean);
+    }
+
+    if (!value) {
+        return [];
+    }
+
+    return String(value)
+        .split(',')
+        .map((userId) => userId.trim())
+        .filter(Boolean);
+};
+
+const buildTaskSelectQuery = (whereSql = '1=1', orderSql = 't.createdAt DESC') => `
+    SELECT
+        t.id,
+        t.title,
+        t.description,
+        t.status,
+        t.priority,
+        t.createdAt,
+        t.updatedAt,
+        GROUP_CONCAT(tu.user_id ORDER BY tu.user_id SEPARATOR ',') AS assignedUserIdsCsv
+    FROM tasks t
+    LEFT JOIN task_users tu ON tu.task_id = t.id
+    WHERE ${whereSql}
+    GROUP BY
+        t.id,
+        t.title,
+        t.description,
+        t.status,
+        t.priority,
+        t.createdAt,
+        t.updatedAt
+    ORDER BY ${orderSql}
+`;
+
+export const formatDateForSQL = (value = new Date()) => {
+    const parsedDate = value instanceof Date ? value : new Date(value);
+
+    return parsedDate.toISOString().slice(0, 19).replace('T', ' ');
+};
+
+export const generateEntityId = () => `${Date.now()}${Math.floor(Math.random() * 1000)}`;
+
+export const mapUserRow = (row) => {
+    if (!row) {
+        return null;
+    }
 
     return {
-        id: String(user.id).trim(),
-        firstName: user.firstName?.trim(),
-        lastName: user.lastName?.trim(),
-        email: user.email?.trim().toLowerCase(),
-        status: user.status?.trim().toLowerCase() || 'activo',
-        role: user.role?.trim().toLowerCase() || 'usuario',
-        password: user.password || 'User12345',
-        createdAt: user.createdAt || timestamp,
-        updatedAt: user.updatedAt || timestamp
+        id: String(row.id).trim(),
+        firstName: row.firstName?.trim(),
+        lastName: row.lastName?.trim(),
+        email: row.email?.trim().toLowerCase(),
+        status: row.status?.trim().toLowerCase() || 'activo',
+        role: row.role?.trim().toLowerCase() || 'usuario',
+        password: row.password,
+        createdAt: normalizeDateValue(row.createdAt),
+        updatedAt: normalizeDateValue(row.updatedAt)
     };
 };
 
-// Normaliza las tareas y evita ids repetidos en las asignaciones.
-const normalizeTask = (task) => {
-    const timestamp = new Date().toISOString();
+export const mapTaskRow = (row) => {
+    if (!row) {
+        return null;
+    }
 
     return {
-        id: String(task.id).trim(),
-        title: task.title?.trim(),
-        description: task.description?.trim() || '',
-        status: task.status?.trim().toLowerCase() === 'en curso'
+        id: String(row.id).trim(),
+        title: row.title?.trim(),
+        description: row.description?.trim?.() ?? row.description ?? '',
+        status: row.status?.trim().toLowerCase() === 'en curso'
             ? 'en progreso'
-            : task.status?.trim().toLowerCase() || 'pendiente',
-        priority: task.priority?.trim().toLowerCase() || 'media',
-        assignedUserIds: Array.isArray(task.assignedUserIds)
-            ? [...new Set(task.assignedUserIds.map((userId) => String(userId).trim()).filter(Boolean))]
-            : [],
-        createdAt: task.createdAt || timestamp,
-        updatedAt: task.updatedAt || timestamp
+            : row.status?.trim().toLowerCase() || 'pendiente',
+        priority: row.priority?.trim().toLowerCase() || 'media',
+        assignedUserIds: parseAssignedUserIds(row.assignedUserIdsCsv ?? row.assignedUserIds),
+        createdAt: normalizeDateValue(row.createdAt),
+        updatedAt: normalizeDateValue(row.updatedAt)
     };
 };
 
-// Estos arreglos simulan la base de datos en memoria.
-export const usersDatabase = Array.isArray(seedData.users)
-    ? seedData.users.map(normalizeUser)
-    : [];
+export const queryTaskRows = async ({
+    executor = pool,
+    whereSql = '1=1',
+    params = [],
+    orderSql = 't.createdAt DESC'
+} = {}) => {
+    const [rows] = await executor.query(buildTaskSelectQuery(whereSql, orderSql), params);
 
-export const tasksDatabase = Array.isArray(seedData.tasks)
-    ? seedData.tasks.map(normalizeTask)
-    : [];
+    return rows.map(mapTaskRow);
+};
+
+export const findTaskByIdInDb = async (taskId, executor = pool) => {
+    const tasks = await queryTaskRows({
+        executor,
+        whereSql: 't.id = ?',
+        params: [taskId],
+        orderSql: 't.createdAt DESC'
+    });
+
+    return tasks[0] || null;
+};
+
+export const findUserByIdInDb = async (userId, executor = pool) => {
+    const [rows] = await executor.query(
+        `SELECT ${USER_SELECT_FIELDS} FROM users WHERE id = ? LIMIT 1`,
+        [userId]
+    );
+
+    return mapUserRow(rows[0]);
+};
+
+export const findUserByEmailInDb = async (email, executor = pool) => {
+    const [rows] = await executor.query(
+        `SELECT ${USER_SELECT_FIELDS} FROM users WHERE email = ? LIMIT 1`,
+        [email]
+    );
+
+    return mapUserRow(rows[0]);
+};
+
+export const ensureUsersExistInDb = async (userIds, executor = pool) => {
+    const normalizedUserIds = [...new Set(
+        userIds
+            .map((userId) => String(userId).trim())
+            .filter(Boolean)
+    )];
+
+    if (normalizedUserIds.length === 0) {
+        return normalizedUserIds;
+    }
+
+    const placeholders = normalizedUserIds.map(() => '?').join(', ');
+    const [rows] = await executor.query(
+        `SELECT id FROM users WHERE id IN (${placeholders})`,
+        normalizedUserIds
+    );
+
+    const foundUserIds = new Set(rows.map((row) => String(row.id).trim()));
+    const missingUserIds = normalizedUserIds.filter((userId) => !foundUserIds.has(userId));
+
+    if (missingUserIds.length > 0) {
+        throw createModelError(`Usuarios no encontrados: ${missingUserIds.join(', ')}`, 404);
+    }
+
+    return normalizedUserIds;
+};
+
+export const withTransaction = async (callback) => {
+    const connection = await pool.getConnection();
+
+    try {
+        await connection.beginTransaction();
+        const result = await callback(connection);
+        await connection.commit();
+
+        return result;
+    } catch (error) {
+        await connection.rollback();
+        throw error;
+    } finally {
+        connection.release();
+    }
+};
+
+export default pool;

--- a/src/models/tasks/assign.model.js
+++ b/src/models/tasks/assign.model.js
@@ -1,6 +1,12 @@
-import { tasksDatabase, usersDatabase } from '../database.js';
+import {
+    ensureUsersExistInDb,
+    findTaskByIdInDb,
+    formatDateForSQL,
+    withTransaction
+} from '../database.js';
 import { createModelError } from '../errors.js';
 import { validateAssignedUserIds } from './helpers.js';
+
 export const assignUsersToTaskModel = async (taskId, userIds) => {
     const normalizedUserIds = validateAssignedUserIds(userIds);
 
@@ -8,28 +14,27 @@ export const assignUsersToTaskModel = async (taskId, userIds) => {
         throw createModelError('Debe enviar al menos un ID de usuario');
     }
 
-    const taskIndex = tasksDatabase.findIndex((task) => task.id === taskId);
+    const existingTask = await findTaskByIdInDb(taskId);
 
-    if (taskIndex === -1) {
+    if (!existingTask) {
         throw createModelError('Tarea no encontrada', 404);
     }
 
-    const missingUserIds = normalizedUserIds.filter(
-        (userId) => !usersDatabase.some((user) => user.id === userId)
-    );
+    await withTransaction(async (connection) => {
+        const validUserIds = await ensureUsersExistInDb(normalizedUserIds, connection);
+        const placeholders = validUserIds.map(() => '(?, ?)').join(', ');
+        const values = validUserIds.flatMap((userId) => [taskId, userId]);
 
-    if (missingUserIds.length > 0) {
-        throw createModelError(`Usuarios no encontrados: ${missingUserIds.join(', ')}`, 404);
-    }
+        await connection.query(
+            `INSERT IGNORE INTO task_users (task_id, user_id) VALUES ${placeholders}`,
+            values
+        );
 
-    // Une los usuarios actuales con los nuevos sin repetir ids.
-    const mergedUserIds = [...new Set([
-        ...tasksDatabase[taskIndex].assignedUserIds,
-        ...normalizedUserIds
-    ])];
+        await connection.query(
+            'UPDATE tasks SET updatedAt = ? WHERE id = ?',
+            [formatDateForSQL(), taskId]
+        );
+    });
 
-    tasksDatabase[taskIndex].assignedUserIds = mergedUserIds;
-    tasksDatabase[taskIndex].updatedAt = new Date().toISOString();
-
-    return tasksDatabase[taskIndex];
+    return findTaskByIdInDb(taskId);
 };

--- a/src/models/tasks/create.model.js
+++ b/src/models/tasks/create.model.js
@@ -1,38 +1,53 @@
-import { tasksDatabase, usersDatabase } from '../database.js';
-import { createModelError } from '../errors.js';
+import {
+    ensureUsersExistInDb,
+    findTaskByIdInDb,
+    formatDateForSQL,
+    generateEntityId,
+    withTransaction
+} from '../database.js';
 import { validateTaskPayload } from './helpers.js';
-
-const generateTaskId = () => `${Date.now()}${Math.floor(Math.random() * 1000)}`;
-// Verifica que los usuarios a asignar existan antes de crear la tarea.
-const validateUsersExist = (userIds) => {
-    const missingUserIds = userIds.filter(
-        (userId) => !usersDatabase.some((user) => user.id === userId)
-    );
-
-    if (missingUserIds.length > 0) {
-        throw createModelError(`Usuarios no encontrados: ${missingUserIds.join(', ')}`, 404);
-    }
-};
 
 export const createTaskModel = async (taskData) => {
     const normalizedData = validateTaskPayload(taskData);
-    const assignedUserIds = normalizedData.assignedUserIds || [];
+    const assignedUserIds = await ensureUsersExistInDb(normalizedData.assignedUserIds || []);
+    const taskId = generateEntityId();
+    const timestamp = formatDateForSQL();
 
-    validateUsersExist(assignedUserIds);
+    await withTransaction(async (connection) => {
+        await connection.query(
+            `
+                INSERT INTO tasks (
+                    id,
+                    title,
+                    description,
+                    status,
+                    priority,
+                    createdAt,
+                    updatedAt
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+            `,
+            [
+                taskId,
+                normalizedData.title,
+                normalizedData.description || '',
+                normalizedData.status || 'pendiente',
+                normalizedData.priority || 'media',
+                timestamp,
+                timestamp
+            ]
+        );
 
-    const timestamp = new Date().toISOString();
-    const newTask = {
-        id: generateTaskId(),
-        title: normalizedData.title,
-        description: normalizedData.description || '',
-        status: normalizedData.status || 'pendiente',
-        priority: normalizedData.priority || 'media',
-        assignedUserIds,
-        createdAt: timestamp,
-        updatedAt: timestamp
-    };
+        if (assignedUserIds.length > 0) {
+            const placeholders = assignedUserIds.map(() => '(?, ?)').join(', ');
+            const values = assignedUserIds.flatMap((userId) => [taskId, userId]);
 
-    tasksDatabase.push(newTask);
+            await connection.query(
+                `INSERT INTO task_users (task_id, user_id) VALUES ${placeholders}`,
+                values
+            );
+        }
+    });
 
-    return newTask;
+    return findTaskByIdInDb(taskId);
 };

--- a/src/models/tasks/delete.model.js
+++ b/src/models/tasks/delete.model.js
@@ -1,14 +1,14 @@
-import { tasksDatabase } from '../database.js';
+import pool, { findTaskByIdInDb } from '../database.js';
 import { createModelError } from '../errors.js';
-export const deleteTaskModel = async (id) => {
-    const taskIndex = tasksDatabase.findIndex((task) => task.id === id);
 
-    if (taskIndex === -1) {
+export const deleteTaskModel = async (id) => {
+    const existingTask = await findTaskByIdInDb(id);
+
+    if (!existingTask) {
         throw createModelError('Tarea no encontrada', 404);
     }
 
-    const deletedTask = tasksDatabase[taskIndex];
-    tasksDatabase.splice(taskIndex, 1);
+    await pool.query('DELETE FROM tasks WHERE id = ?', [id]);
 
-    return deletedTask;
+    return existingTask;
 };

--- a/src/models/tasks/filter.model.js
+++ b/src/models/tasks/filter.model.js
@@ -1,5 +1,5 @@
-import { tasksDatabase } from '../database.js';
 import { createModelError } from '../errors.js';
+import { formatDateForSQL, queryTaskRows } from '../database.js';
 import { normalizeTaskStatus } from './helpers.js';
 
 const normalizeDateBoundary = (value, { endOfDay = false } = {}) => {
@@ -29,14 +29,43 @@ export const filterTasksModel = async ({ userId, status, priority, dateFrom, dat
         throw createModelError('La fecha inicial no puede ser mayor que la fecha final');
     }
 
-    return tasksDatabase.filter((task) => {
-        const matchesUser = userId ? task.assignedUserIds.includes(userId) : true;
-        const matchesStatus = normalizedStatus ? task.status === normalizedStatus : true;
-        const matchesPriority = priority ? task.priority === priority : true;
-        const createdAt = new Date(task.createdAt);
-        const matchesDateFrom = parsedDateFrom ? createdAt >= parsedDateFrom : true;
-        const matchesDateTo = parsedDateTo ? createdAt <= parsedDateTo : true;
+    const whereClauses = ['1=1'];
+    const params = [];
 
-        return matchesUser && matchesStatus && matchesPriority && matchesDateFrom && matchesDateTo;
+    if (userId) {
+        whereClauses.push(`
+            EXISTS (
+                SELECT 1
+                FROM task_users tu_filter
+                WHERE tu_filter.task_id = t.id
+                  AND tu_filter.user_id = ?
+            )
+        `);
+        params.push(userId);
+    }
+
+    if (normalizedStatus) {
+        whereClauses.push('t.status = ?');
+        params.push(normalizedStatus);
+    }
+
+    if (priority) {
+        whereClauses.push('t.priority = ?');
+        params.push(priority);
+    }
+
+    if (parsedDateFrom) {
+        whereClauses.push('t.createdAt >= ?');
+        params.push(formatDateForSQL(parsedDateFrom));
+    }
+
+    if (parsedDateTo) {
+        whereClauses.push('t.createdAt <= ?');
+        params.push(formatDateForSQL(parsedDateTo));
+    }
+
+    return queryTaskRows({
+        whereSql: whereClauses.join(' AND '),
+        params
     });
 };

--- a/src/models/tasks/findAll.model.js
+++ b/src/models/tasks/findAll.model.js
@@ -1,4 +1,5 @@
-import { tasksDatabase } from '../database.js';
+import { queryTaskRows } from '../database.js';
+
 export const findAllTasksModel = async () => {
-    return tasksDatabase;
+    return queryTaskRows();
 };

--- a/src/models/tasks/findById.model.js
+++ b/src/models/tasks/findById.model.js
@@ -1,4 +1,5 @@
-import { tasksDatabase } from '../database.js';
+import { findTaskByIdInDb } from '../database.js';
+
 export const findTaskByIdModel = async (id) => {
-    return tasksDatabase.find((task) => task.id === id);
+    return findTaskByIdInDb(id);
 };

--- a/src/models/tasks/findByUserId.model.js
+++ b/src/models/tasks/findByUserId.model.js
@@ -1,4 +1,15 @@
-import { tasksDatabase } from '../database.js';
+import { queryTaskRows } from '../database.js';
+
 export const findTasksByUserIdModel = async (userId) => {
-    return tasksDatabase.filter((task) => task.assignedUserIds.includes(userId));
+    return queryTaskRows({
+        whereSql: `
+            EXISTS (
+                SELECT 1
+                FROM task_users tu_filter
+                WHERE tu_filter.task_id = t.id
+                  AND tu_filter.user_id = ?
+            )
+        `,
+        params: [userId]
+    });
 };

--- a/src/models/tasks/findUsersByTaskId.model.js
+++ b/src/models/tasks/findUsersByTaskId.model.js
@@ -1,12 +1,32 @@
-import { tasksDatabase, usersDatabase } from '../database.js';
+import pool, { findTaskByIdInDb, mapUserRow } from '../database.js';
 import { createModelError } from '../errors.js';
 
 export const findUsersByTaskIdModel = async (taskId) => {
-    const task = tasksDatabase.find((currentTask) => currentTask.id === taskId);
+    const task = await findTaskByIdInDb(taskId);
 
     if (!task) {
         throw createModelError('Tarea no encontrada', 404);
     }
 
-    return usersDatabase.filter((user) => task.assignedUserIds.includes(user.id));
+    const [rows] = await pool.query(
+        `
+            SELECT
+                u.id,
+                u.firstName,
+                u.lastName,
+                u.email,
+                u.status,
+                u.role,
+                u.password,
+                u.createdAt,
+                u.updatedAt
+            FROM users u
+            INNER JOIN task_users tu ON tu.user_id = u.id
+            WHERE tu.task_id = ?
+            ORDER BY u.createdAt DESC
+        `,
+        [taskId]
+    );
+
+    return rows.map(mapUserRow);
 };

--- a/src/models/tasks/removeUserAssignments.model.js
+++ b/src/models/tasks/removeUserAssignments.model.js
@@ -1,19 +1,26 @@
-import { tasksDatabase } from '../database.js';
-export const removeUserAssignmentsModel = async (userId) => {
-    let updatedTasks = 0;
+import { formatDateForSQL, withTransaction } from '../database.js';
 
-    tasksDatabase.forEach((task) => {
-        if (!task.assignedUserIds.includes(userId)) {
-            return;
+export const removeUserAssignmentsModel = async (userId) => {
+    return withTransaction(async (connection) => {
+        const [rows] = await connection.query(
+            'SELECT DISTINCT task_id FROM task_users WHERE user_id = ?',
+            [userId]
+        );
+
+        if (rows.length === 0) {
+            return 0;
         }
 
-        // Elimina al usuario de la lista de asignados de la tarea.
-        task.assignedUserIds = task.assignedUserIds.filter(
-            (assignedUserId) => assignedUserId !== userId
-        );
-        task.updatedAt = new Date().toISOString();
-        updatedTasks += 1;
-    });
+        await connection.query('DELETE FROM task_users WHERE user_id = ?', [userId]);
 
-    return updatedTasks;
+        const taskIds = rows.map((row) => String(row.task_id));
+        const placeholders = taskIds.map(() => '?').join(', ');
+
+        await connection.query(
+            `UPDATE tasks SET updatedAt = ? WHERE id IN (${placeholders})`,
+            [formatDateForSQL(), ...taskIds]
+        );
+
+        return taskIds.length;
+    });
 };

--- a/src/models/tasks/removeUserFromTask.model.js
+++ b/src/models/tasks/removeUserFromTask.model.js
@@ -1,27 +1,39 @@
-import { tasksDatabase, usersDatabase } from '../database.js';
+import {
+    findTaskByIdInDb,
+    findUserByIdInDb,
+    formatDateForSQL,
+    withTransaction
+} from '../database.js';
 import { createModelError } from '../errors.js';
 
 export const removeUserFromTaskModel = async (taskId, userId) => {
-    const taskIndex = tasksDatabase.findIndex((task) => task.id === taskId);
+    const existingTask = await findTaskByIdInDb(taskId);
 
-    if (taskIndex === -1) {
+    if (!existingTask) {
         throw createModelError('Tarea no encontrada', 404);
     }
 
-    const userExists = usersDatabase.some((user) => user.id === userId);
+    const existingUser = await findUserByIdInDb(userId);
 
-    if (!userExists) {
+    if (!existingUser) {
         throw createModelError('Usuario no encontrado', 404);
     }
 
-    if (!tasksDatabase[taskIndex].assignedUserIds.includes(userId)) {
-        throw createModelError('El usuario no está asignado a esta tarea', 404);
-    }
+    await withTransaction(async (connection) => {
+        const [result] = await connection.query(
+            'DELETE FROM task_users WHERE task_id = ? AND user_id = ?',
+            [taskId, userId]
+        );
 
-    tasksDatabase[taskIndex].assignedUserIds = tasksDatabase[taskIndex].assignedUserIds.filter(
-        (assignedUserId) => assignedUserId !== userId
-    );
-    tasksDatabase[taskIndex].updatedAt = new Date().toISOString();
+        if (result.affectedRows === 0) {
+            throw createModelError('El usuario no está asignado a esta tarea', 404);
+        }
 
-    return tasksDatabase[taskIndex];
+        await connection.query(
+            'UPDATE tasks SET updatedAt = ? WHERE id = ?',
+            [formatDateForSQL(), taskId]
+        );
+    });
+
+    return findTaskByIdInDb(taskId);
 };

--- a/src/models/tasks/update.model.js
+++ b/src/models/tasks/update.model.js
@@ -1,32 +1,63 @@
-import { tasksDatabase, usersDatabase } from '../database.js';
+import {
+    ensureUsersExistInDb,
+    findTaskByIdInDb,
+    formatDateForSQL,
+    withTransaction
+} from '../database.js';
 import { createModelError } from '../errors.js';
 import { validateTaskPayload } from './helpers.js';
-export const updateTaskModel = async (id, taskData) => {
-    const taskIndex = tasksDatabase.findIndex((task) => task.id === id);
 
-    if (taskIndex === -1) {
+export const updateTaskModel = async (id, taskData) => {
+    const existingTask = await findTaskByIdInDb(id);
+
+    if (!existingTask) {
         throw createModelError('Tarea no encontrada', 404);
     }
 
     const normalizedData = validateTaskPayload(taskData, { partial: true });
 
-    if (normalizedData.assignedUserIds !== undefined) {
-        const missingUserIds = normalizedData.assignedUserIds.filter(
-            (userId) => !usersDatabase.some((user) => user.id === userId)
+    await withTransaction(async (connection) => {
+        if (normalizedData.assignedUserIds !== undefined) {
+            normalizedData.assignedUserIds = await ensureUsersExistInDb(
+                normalizedData.assignedUserIds,
+                connection
+            );
+        }
+
+        const fieldsToUpdate = [];
+        const values = [];
+
+        ['title', 'description', 'status', 'priority'].forEach((field) => {
+            if (normalizedData[field] === undefined) {
+                return;
+            }
+
+            fieldsToUpdate.push(`${field} = ?`);
+            values.push(normalizedData[field]);
+        });
+
+        fieldsToUpdate.push('updatedAt = ?');
+        values.push(formatDateForSQL(), id);
+
+        await connection.query(
+            `UPDATE tasks SET ${fieldsToUpdate.join(', ')} WHERE id = ?`,
+            values
         );
 
-        if (missingUserIds.length > 0) {
-            throw createModelError(`Usuarios no encontrados: ${missingUserIds.join(', ')}`, 404);
+        if (normalizedData.assignedUserIds !== undefined) {
+            await connection.query('DELETE FROM task_users WHERE task_id = ?', [id]);
+
+            if (normalizedData.assignedUserIds.length > 0) {
+                const placeholders = normalizedData.assignedUserIds.map(() => '(?, ?)').join(', ');
+                const assignmentValues = normalizedData.assignedUserIds.flatMap((userId) => [id, userId]);
+
+                await connection.query(
+                    `INSERT INTO task_users (task_id, user_id) VALUES ${placeholders}`,
+                    assignmentValues
+                );
+            }
         }
-    }
+    });
 
-    const updatedTask = {
-        ...tasksDatabase[taskIndex],
-        ...normalizedData,
-        updatedAt: new Date().toISOString()
-    };
-
-    tasksDatabase[taskIndex] = updatedTask;
-
-    return updatedTask;
+    return findTaskByIdInDb(id);
 };

--- a/src/models/tasks/updateStatus.model.js
+++ b/src/models/tasks/updateStatus.model.js
@@ -1,6 +1,7 @@
-import { tasksDatabase } from '../database.js';
+import pool, { findTaskByIdInDb, formatDateForSQL } from '../database.js';
 import { createModelError } from '../errors.js';
 import { normalizeTaskStatus, VALID_TASK_STATUSES } from './helpers.js';
+
 export const updateTaskStatusModel = async (id, status) => {
     const normalizedStatus = normalizeTaskStatus(status);
 
@@ -8,14 +9,16 @@ export const updateTaskStatusModel = async (id, status) => {
         throw createModelError('Estado inválido. Debe ser: pendiente, en progreso o completada');
     }
 
-    const taskIndex = tasksDatabase.findIndex((task) => task.id === id);
+    const existingTask = await findTaskByIdInDb(id);
 
-    if (taskIndex === -1) {
+    if (!existingTask) {
         throw createModelError('Tarea no encontrada', 404);
     }
 
-    tasksDatabase[taskIndex].status = normalizedStatus;
-    tasksDatabase[taskIndex].updatedAt = new Date().toISOString();
+    await pool.query(
+        'UPDATE tasks SET status = ?, updatedAt = ? WHERE id = ?',
+        [normalizedStatus, formatDateForSQL(), id]
+    );
 
-    return tasksDatabase[taskIndex];
+    return findTaskByIdInDb(id);
 };

--- a/src/models/users/create.model.js
+++ b/src/models/users/create.model.js
@@ -1,28 +1,50 @@
-import { usersDatabase } from './database.js';
+import pool, {
+    findUserByEmailInDb,
+    findUserByIdInDb,
+    formatDateForSQL,
+    generateEntityId
+} from '../database.js';
 import { createModelError } from '../errors.js';
 import { validateUserPayload } from './helpers.js';
 
-const generateUserId = () => `${Date.now()}${Math.floor(Math.random() * 1000)}`;
 export const createModel = async (userData) => {
     const normalizedData = validateUserPayload(userData);
+    const existingUser = await findUserByEmailInDb(normalizedData.email);
 
-    const existingUser = usersDatabase.find((user) => user.email === normalizedData.email);
     if (existingUser) {
         throw createModelError('El email ya existe');
     }
 
-    const timestamp = new Date().toISOString();
-    const newUser = {
-        id: generateUserId(),
-        ...normalizedData,
-        status: normalizedData.status || 'activo',
-        role: normalizedData.role || 'usuario',
-        password: normalizedData.password || 'User12345',
-        createdAt: timestamp,
-        updatedAt: timestamp
-    };
+    const userId = generateEntityId();
+    const timestamp = formatDateForSQL();
 
-    usersDatabase.push(newUser);
+    await pool.query(
+        `
+            INSERT INTO users (
+                id,
+                firstName,
+                lastName,
+                email,
+                status,
+                role,
+                password,
+                createdAt,
+                updatedAt
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `,
+        [
+            userId,
+            normalizedData.firstName,
+            normalizedData.lastName,
+            normalizedData.email,
+            normalizedData.status || 'activo',
+            normalizedData.role || 'usuario',
+            normalizedData.password || 'User12345',
+            timestamp,
+            timestamp
+        ]
+    );
 
-    return newUser;
+    return findUserByIdInDb(userId);
 };

--- a/src/models/users/database.js
+++ b/src/models/users/database.js
@@ -1,2 +1,2 @@
-// Reexport para mantener la estructura del modulo de usuarios.
-export { usersDatabase } from '../database.js';
+// Reexport de helpers de base de datos para el modulo de usuarios.
+export { findUserByEmailInDb, findUserByIdInDb } from '../database.js';

--- a/src/models/users/delete.model.js
+++ b/src/models/users/delete.model.js
@@ -1,14 +1,36 @@
-import { usersDatabase } from './database.js';
+import {
+    findUserByIdInDb,
+    formatDateForSQL,
+    withTransaction
+} from '../database.js';
 import { createModelError } from '../errors.js';
-export const deleteModel = async (id) => {
-    const userIndex = usersDatabase.findIndex((user) => user.id === id);
 
-    if (userIndex === -1) {
+export const deleteModel = async (id) => {
+    const existingUser = await findUserByIdInDb(id);
+
+    if (!existingUser) {
         throw createModelError('Usuario no encontrado', 404);
     }
 
-    const deletedUser = usersDatabase[userIndex];
-    usersDatabase.splice(userIndex, 1);
+    await withTransaction(async (connection) => {
+        const [rows] = await connection.query(
+            'SELECT DISTINCT task_id FROM task_users WHERE user_id = ?',
+            [id]
+        );
 
-    return deletedUser;
+        if (rows.length > 0) {
+            const taskIds = rows.map((row) => String(row.task_id));
+            const placeholders = taskIds.map(() => '?').join(', ');
+
+            await connection.query('DELETE FROM task_users WHERE user_id = ?', [id]);
+            await connection.query(
+                `UPDATE tasks SET updatedAt = ? WHERE id IN (${placeholders})`,
+                [formatDateForSQL(), ...taskIds]
+            );
+        }
+
+        await connection.query('DELETE FROM users WHERE id = ?', [id]);
+    });
+
+    return existingUser;
 };

--- a/src/models/users/findAll.model.js
+++ b/src/models/users/findAll.model.js
@@ -1,4 +1,20 @@
-import { usersDatabase } from './database.js';
+import pool, { mapUserRow } from '../database.js';
+
 export const findAllModel = async () => {
-    return usersDatabase;
+    const [rows] = await pool.query(`
+        SELECT
+            id,
+            firstName,
+            lastName,
+            email,
+            status,
+            role,
+            password,
+            createdAt,
+            updatedAt
+        FROM users
+        ORDER BY createdAt DESC
+    `);
+
+    return rows.map(mapUserRow);
 };

--- a/src/models/users/findById.model.js
+++ b/src/models/users/findById.model.js
@@ -1,4 +1,5 @@
-import { usersDatabase } from './database.js';
+import { findUserByIdInDb } from '../database.js';
+
 export const findByIdModel = async (id) => {
-    return usersDatabase.find((user) => user.id === id);
+    return findUserByIdInDb(id);
 };

--- a/src/models/users/update.model.js
+++ b/src/models/users/update.model.js
@@ -1,32 +1,43 @@
-import { usersDatabase } from './database.js';
+import pool, {
+    findUserByEmailInDb,
+    findUserByIdInDb,
+    formatDateForSQL
+} from '../database.js';
 import { createModelError } from '../errors.js';
 import { validateUserPayload } from './helpers.js';
-export const updateModel = async (id, userData) => {
-    const userIndex = usersDatabase.findIndex((user) => user.id === id);
 
-    if (userIndex === -1) {
+export const updateModel = async (id, userData) => {
+    const existingUser = await findUserByIdInDb(id);
+
+    if (!existingUser) {
         throw createModelError('Usuario no encontrado', 404);
     }
 
     const normalizedData = validateUserPayload(userData, { partial: true });
 
     if (normalizedData.email) {
-        const existingUser = usersDatabase.find(
-            (user) => user.email === normalizedData.email && user.id !== id
-        );
+        const duplicatedUser = await findUserByEmailInDb(normalizedData.email);
 
-        if (existingUser) {
+        if (duplicatedUser && duplicatedUser.id !== id) {
             throw createModelError('El email ya existe');
         }
     }
 
-    const updatedUser = {
-        ...usersDatabase[userIndex],
-        ...normalizedData,
-        updatedAt: new Date().toISOString()
-    };
+    const fieldsToUpdate = [];
+    const values = [];
 
-    usersDatabase[userIndex] = updatedUser;
+    Object.entries(normalizedData).forEach(([field, value]) => {
+        fieldsToUpdate.push(`${field} = ?`);
+        values.push(value);
+    });
 
-    return updatedUser;
+    fieldsToUpdate.push('updatedAt = ?');
+    values.push(formatDateForSQL(), id);
+
+    await pool.query(
+        `UPDATE users SET ${fieldsToUpdate.join(', ')} WHERE id = ?`,
+        values
+    );
+
+    return findUserByIdInDb(id);
 };

--- a/src/models/users/updateStatus.model.js
+++ b/src/models/users/updateStatus.model.js
@@ -1,6 +1,7 @@
-import { usersDatabase } from './database.js';
+import pool, { findUserByIdInDb, formatDateForSQL } from '../database.js';
 import { createModelError } from '../errors.js';
 import { VALID_USER_STATUSES } from './helpers.js';
+
 export const updateStatusModel = async (id, status) => {
     const normalizedStatus = status?.trim().toLowerCase();
 
@@ -8,14 +9,16 @@ export const updateStatusModel = async (id, status) => {
         throw createModelError('Estado inválido. Debe ser: activo, inactivo, suspendido o eliminado');
     }
 
-    const userIndex = usersDatabase.findIndex((user) => user.id === id);
+    const existingUser = await findUserByIdInDb(id);
 
-    if (userIndex === -1) {
+    if (!existingUser) {
         throw createModelError('Usuario no encontrado', 404);
     }
 
-    usersDatabase[userIndex].status = normalizedStatus;
-    usersDatabase[userIndex].updatedAt = new Date().toISOString();
+    await pool.query(
+        'UPDATE users SET status = ?, updatedAt = ? WHERE id = ?',
+        [normalizedStatus, formatDateForSQL(), id]
+    );
 
-    return usersDatabase[userIndex];
+    return findUserByIdInDb(id);
 };


### PR DESCRIPTION
## Resumen
Este PR reemplaza la persistencia en memoria del backend por consultas reales a MySQL, manteniendo los mismos endpoints y contratos actuales de la API.

## Cambios realizados
- Se migra la capa de modelos de usuarios, tareas, autenticación y dashboard para usar MySQL.
- Se centralizan helpers de acceso a datos, mapeo de filas y transacciones.
- Se integra la relación N:M entre tareas y usuarios mediante la tabla `task_users`.
- Se agrega un script SQL para crear el usuario de aplicación de la base de datos.
- Se actualizan los valores por defecto de conexión y el `.env.example`.

## Impacto
- No se cambian rutas, métodos HTTP ni payloads del API.
- El estado de las tareas sigue siendo global por tarea.
- La lógica existente de asignación múltiple se conserva, pero ahora respaldada por MySQL.

## Validación
- El backend carga correctamente a nivel de imports y wiring de modelos.
- Se validó la instalación de dependencias necesarias (`mysql2`, `dotenv`).
- La validación completa contra MySQL real depende de contar con credenciales válidas en `.env`.

## Archivos relevantes
- `src/config/db.js`
- `src/models/database.js`
- `src/models/users/*`
- `src/models/tasks/*`
- `src/models/auth/login.model.js`
- `src/models/dashboard/get.model.js`
- `database-user.sql`

## Notas
Para probar este cambio se debe:
1. Crear la base con `database.sql`
2. Crear el usuario de aplicación con `database-user.sql`
3. Configurar `.env` con las credenciales de MySQL
4. Levantar el backend normalmente
